### PR TITLE
issue6: add docker configuration

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:24.11.0-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY apps/api/package.json ./apps/api/
+COPY packages ./packages
+
+RUN npm ci
+
+COPY apps/api ./apps/api
+
+RUN npm run build --workspace=api
+
+FROM node:24.11.0-alpine AS runner
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY apps/api/package.json ./apps/api/
+COPY packages ./packages
+
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/apps/api/dist ./apps/api/dist
+
+EXPOSE 5001
+
+CMD ["node", "apps/api/dist/index.js"]

--- a/apps/api/docker-compose.yml
+++ b/apps/api/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  api:
+    container_name: pixelated_api
+    build:
+      context: ../../
+      dockerfile: apps/api/Dockerfile
+    ports:
+      - "${API_PORT}:5001"
+    networks:
+      - pixelated_network
+    environment:
+      - PORT=${PORT}
+      - JWT_SECRET=${JWT_SECRET}
+      - WEB_SOCKET_URL=${WEB_SOCKET_URL}
+      - REDIS_HOST=${REDIS_HOST}
+      - REDIS_PORT=${REDIS_PORT}
+      - REDIS_URL=${REDIS_URL}
+      - ENV=${ENV}
+    depends_on:
+      - redis
+
+  redis:
+    container_name: pixelated_api_redis
+    image: bitnami/redis:latest
+    ports:
+      - "${REDIS_PORT}:6379"
+    networks:
+      - pixelated_network
+    environment:
+      - ALLOW_EMPTY_PASSWORD=yes
+    volumes:
+      - pixelated_api_redis_data:/bitnami/redis/data
+
+networks:
+  pixelated_network:
+    driver: bridge
+
+volumes:
+  pixelated_api_redis_data:


### PR DESCRIPTION
- REDIS_URL = "redis://name-service-redis:6379" -> ""redis://redis:6379"
- ADD REDIS_URL in /apps/api/.env in your .env.example is empty.
- apps/api/index.ts in line 25 insert process.env.REDIS_URL.
- npm run build in apps/api not working if packages/jwt not builded.